### PR TITLE
Validate weapon slot before handling drops

### DIFF
--- a/server/weapon_drop.lua
+++ b/server/weapon_drop.lua
@@ -1,9 +1,18 @@
 local ox_inventory = exports["ox_inventory"]
 
 RegisterNetEvent('mbt_malisling:dropWeapon', function(data)
-    if type(data.slot) ~= 'number' then return end
-    local item = ox_inventory:GetSlot(source, data.slot)
-    if not item then return end
+    local slot = data and data.slot
+    if type(slot) ~= 'number' then
+        warn(('dropWeapon: invalid slot from %s'):format(source))
+        return
+    end
+
+    local item = ox_inventory:GetSlot(source, slot)
+    if not item then
+        warn(('dropWeapon: no item in slot %s from %s'):format(slot, source))
+        return
+    end
+
     if ox_inventory:RemoveItem(source, item.name, item.count, nil, item.slot) then
         ox_inventory:CustomDrop(('DeadDrop %s000000000'):format(os.time()),
             { { item.name, item.count, item.metadata } },

--- a/server/weapon_throw.lua
+++ b/server/weapon_throw.lua
@@ -1,9 +1,17 @@
 local ox_inventory = exports["ox_inventory"]
 
 RegisterNetEvent('mbt_malisling:createWeaponDrop', function(data)
-    if type(data.WeaponInfo?.slot) ~= 'number' then return end
-    local item = ox_inventory:GetSlot(source, data.WeaponInfo.slot)
-    if not item then return end
+    local slot = data and data.WeaponInfo and data.WeaponInfo.slot
+    if type(slot) ~= 'number' then
+        warn(('createWeaponDrop: invalid slot from %s'):format(source))
+        return
+    end
+
+    local item = ox_inventory:GetSlot(source, slot)
+    if not item then
+        warn(('createWeaponDrop: no item in slot %s from %s'):format(slot, source))
+        return
+    end
 
     local coords = GetEntityCoords(GetPlayerPed(source))
     if #(coords - data.Coords) > 10.0 then return end -- drop must be near player


### PR DESCRIPTION
## Summary
- ensure server weapon drop and throw events validate slot and item existence
- log invalid slot attempts and only remove inventory after validation

## Testing
- `luacheck weapon_system/server/weapon_drop.lua weapon_system/server/weapon_throw.lua` *(fails: expected expression near '`', FiveM-specific syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68a18231e14c833293399db8dff7f3ea