### PR TITLE
Validate weapon throw coordinates

### DIFF
--- a/server/weapon_throw.lua
+++ b/server/weapon_throw.lua
@@ -14,7 +14,11 @@ RegisterNetEvent('mbt_malisling:createWeaponDrop', function(data)
     end
 
     local coords = GetEntityCoords(GetPlayerPed(source))
-    if #(coords - data.Coords) > 10.0 then return end -- drop must be near player
+    if type(data.Coords) ~= 'vector3' or #(coords - data.Coords) > 10.0 then
+        warn(('createWeaponDrop: invalid coords from %s'):format(source))
+        return
+    end
+    data.Coords = coords
 
     if ox_inventory:RemoveItem(source, item.name, item.count, nil, item.slot) then
         ox_inventory:CustomDrop(('ThrownDrop %s000000000'):format(os.time()),


### PR DESCRIPTION
## Summary
- ensure weapon drop coordinates come from the server by validating and overriding client-provided coords

## Testing
- `luac -p server/weapon_throw.lua` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a182fb689c83329176fdaede82f591