### PR TITLE
feat: send animation data via server

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -151,7 +151,7 @@ local function sendAnimations(jobName)
         propInfoTable = utils.tableDeepCopy(MBT.PropInfo)
     end
 
-    TriggerEvent("mbt_malisling:sendAnim", {
+    TriggerServerEvent("mbt_malisling:sendAnim", {
         WeaponData = MBT.WeaponsInfo,
         HolsterData = propInfoTable
     })
@@ -457,7 +457,7 @@ elseif isOX then
             end
         end
 
-        TriggerEvent("mbt_malisling:sendAnim", {
+        TriggerServerEvent("mbt_malisling:sendAnim", {
             WeaponData = MBT.WeaponsInfo,
             HolsterData = propInfoTable
         })

--- a/server/main.lua
+++ b/server/main.lua
@@ -261,7 +261,7 @@ AddEventHandler("mbt_malisling:sendAnim", function (data)
     end
 
     local wInfo = weaponData["Weapons"]
-    local Items = require 'modules.items.shared'
+    local validated = {}
 
     for itemName, weapon in pairs(wInfo) do
         if type(weapon) ~= 'table' then
@@ -289,11 +289,15 @@ AddEventHandler("mbt_malisling:sendAnim", function (data)
             end
 
             local animTable = {animInfo.dict, animInfo.animIn, animInfo.sleep, animInfo.dict, animInfo.animOut, animInfo.sleepOut}
+            validated[itemName] = { type = itemType, anim = animTable }
+        end
+    end
 
-            if Items[itemName] then
-                Items[itemName]["type"] = itemType
-                Items[itemName]["anim"] = animTable
-            end
+    local Items = require 'modules.items.shared'
+    for itemName, info in pairs(validated) do
+        if Items[itemName] then
+            Items[itemName]["type"] = info.type
+            Items[itemName]["anim"] = info.anim
         end
     end
 end)


### PR DESCRIPTION
## Summary
- send weapon animation config to server instead of local client event
- validate payload before mutating Items table

## Testing
- `luacheck client/main.lua server/main.lua` *(fails: expected statement near '?')*


------
https://chatgpt.com/codex/tasks/task_e_68a19477676c8332ac7c44be32c60c44