### PR TITLE
Track weapon durability and server-side jamming

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,6 +8,8 @@ local FrameworkObj = {}
 local isReady = false
 local ox_inventory = exports["ox_inventory"]
 local playersToTrack = state.playersToTrack
+local weaponDurability = state.weaponDurability
+local lastJam = state.lastJam
 local addPlayerToPlayerScope = scopesModule.addPlayerToPlayerScope
 local removePlayerFromScopes = scopesModule.removePlayerFromScopes
 local TriggerScopeEvent = scopesModule.TriggerScopeEvent
@@ -70,6 +72,8 @@ local function dropPlayer(s)
         { playerSource = s, weaponType = "all", calledBy = "dropPlayer" })
     TriggerClientEvent("mbt_malisling:syncPlayerRemoval", -1, { playerSource = s })
     playersToTrack[s] = nil
+    weaponDurability[s] = nil
+    lastJam[s] = nil
     removePlayerFromScopes(s)
 end
 
@@ -86,6 +90,8 @@ if isESX then
     RegisterNetEvent('esx:playerLoaded')
     AddEventHandler('esx:playerLoaded', function(playerId)
         playersToTrack[playerId] = {}
+        weaponDurability[playerId] = {}
+        lastJam[playerId] = 0
     end)
 
     getPlayerJob = function (s)
@@ -107,6 +113,8 @@ elseif isQB then
     AddEventHandler('QBCore:Server:PlayerLoaded', function(qbPlayer)
         local source = qbPlayer.PlayerData.source
         playersToTrack[source] = {}
+        weaponDurability[source] = {}
+        lastJam[source] = 0
     end)
 
     getPlayerJob = function (s)
@@ -130,6 +138,8 @@ elseif isOX then
 
     AddEventHandler('ox:playerLoaded', function(source, userid, charid)
         playersToTrack[source] = {}
+        weaponDurability[source] = {}
+        lastJam[source] = 0
     end)
 end
 
@@ -213,4 +223,72 @@ AddEventHandler("mbt_malisling:syncDeletion", function(weaponType)
             weaponType = weaponType
         }
     })
+end)
+
+RegisterNetEvent('mbt_malisling:shotFired', function(slot)
+    local src = source
+    if not slot then return end
+
+    local weaponData = ox_inventory:GetSlot(src, slot)
+    if not weaponData or not weaponData.metadata then return end
+
+    local durability = weaponData.metadata.durability or 100
+    durability = math.max(durability - 1, 0)
+    weaponData.metadata.durability = durability
+    ox_inventory:SetMetadata(src, slot, weaponData.metadata)
+
+    weaponDurability[src] = weaponDurability[src] or {}
+    local serial = weaponData.metadata.serial or slot
+    weaponDurability[src][serial] = durability
+
+    local now = GetGameTimer()
+    local cooldown = (MBT.Jamming["Cooldown"] or 0) * 1000
+    lastJam[src] = lastJam[src] or 0
+    if now - lastJam[src] >= cooldown and utils.getJammingChance(durability) then
+        lastJam[src] = now
+        local player = Player(src)
+        if player then
+            player.state:set('JammedState', true, true)
+        end
+    end
+end)
+
+RegisterNetEvent('mbt_malisling:unjamWeapon', function()
+    local src = source
+    local player = Player(src)
+    if player then
+        player.state:set('JammedState', false, true)
+    end
+end)
+
+RegisterNetEvent('mbt_malisling:repairWeapon', function(data)
+    local src = source
+    if type(data) ~= 'table' then return end
+
+    local slot = data.slot
+    local item = data.item
+    if not slot or not item then return end
+
+    local weaponData = ox_inventory:GetSlot(src, slot)
+    if not weaponData or not weaponData.metadata then return end
+
+    local repairItem = ox_inventory:GetItem(src, item, nil, true)
+    if not repairItem or repairItem.count < 1 then return end
+
+    local durability = weaponData.metadata.durability or 100
+    if durability >= 100 then return end
+
+    weaponData.metadata.durability = 100
+    ox_inventory:SetMetadata(src, slot, weaponData.metadata)
+
+    weaponDurability[src] = weaponDurability[src] or {}
+    local serial = weaponData.metadata.serial or slot
+    weaponDurability[src][serial] = 100
+
+    local player = Player(src)
+    if player then
+        player.state:set('JammedState', false, true)
+    end
+
+    ox_inventory:RemoveItem(src, item, 1)
 end)

--- a/server/state.lua
+++ b/server/state.lua
@@ -1,6 +1,8 @@
 local state = {
     playersToTrack = {},
-    scopes = {}
+    scopes = {},
+    weaponDurability = {},
+    lastJam = {}
 }
 
 return state


### PR DESCRIPTION
## Summary
- track weapon durability and jam timers in server state
- move jamming logic server-side and decrement durability on shots
- validate repair kit usage before removing items

## Testing
- `luacheck .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a2b9ebc3208332bdb2573422bf6085