### PR TITLE
Refactor fire mode to events and drop legacy frameworks

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -2,8 +2,6 @@ local utils = require 'utils'
 local state = require 'server.state'
 local scopesModule = require 'server.scopes'
 local isESX = GetResourceState("es_extended") ~= "missing"
-local isQB = GetResourceState("qb-core") ~= "missing"
-local isOX = GetResourceState("ox_core") ~= "missing"
 local FrameworkObj = {}
 local isReady = false
 local ox_inventory = exports["ox_inventory"]
@@ -94,43 +92,16 @@ if isESX then
         if not xPlayer then return "" end
         return xPlayer.job.name
     end
-    
+
     getPlayerSex = function (s)
         s = tonumber(s)
         local xPlayer = FrameworkObj.GetPlayerFromId(s)
         if not xPlayer then return "male" end
         return xPlayer.get("sex") == "m" and "male" or "female"
     end
-
-elseif isQB then
-    FrameworkObj = exports["qb-core"]:GetCoreObject()
-    AddEventHandler('QBCore:Server:PlayerLoaded', function(qbPlayer)
-        local source = qbPlayer.PlayerData.source
-        playersToTrack[source] = {}
-    end)
-
-    getPlayerJob = function (s)
-        s = tonumber(s)
-        local xPlayer  = FrameworkObj.Functions.GetPlayer(s)
-        if not xPlayer then return "male" end
-        return xPlayer.PlayerData.job.name
-    end
-    
-    getPlayerSex = function (s)
-        s = tonumber(s)
-        local xPlayer  = FrameworkObj.Functions.GetPlayer(s)
-        if not xPlayer then return "male" end
-        return xPlayer.PlayerData.charinfo.gender == 0 and "male" or "female"
-    end
-elseif isOX then
-    local file = ('imports/%s.lua'):format(IsDuplicityVersion() and 'server' or 'client')
-    local import = LoadResourceFile('ox_core', file)
-    local chunk = assert(load(import, ('@@ox_core/%s'):format(file)))
-    chunk()
-
-    AddEventHandler('ox:playerLoaded', function(source, userid, charid)
-        playersToTrack[source] = {}
-    end)
+else
+    getPlayerJob = function () return "" end
+    getPlayerSex = function () return "male" end
 end
 
 


### PR DESCRIPTION
## Summary
- Trigger fire mode logic and limp effects from events instead of polling
- Remove QB Core and ox_core framework support

## Testing
- `luac -p client/weapon_firemode.lua server/main.lua client/main.lua` *(fails: unexpected symbol near '\`')*
- `luacheck client/weapon_firemode.lua server/main.lua client/main.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ba2da94c8332827d0d9f234d0014